### PR TITLE
Check that file exist before unlinking it

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,4 +1,4 @@
-import { unlinkSync } from 'fs';
+import { existsSync, unlinkSync } from 'fs';
 import LoadablePlugin from '@loadable/webpack-plugin';
 import { statsFilename, statsPath } from './constants';
 
@@ -16,5 +16,7 @@ export const onCreateBabelConfig = ({ actions }) => {
 
 export const onPostBuild = () => {
   // Clean after ourselves
-  unlinkSync(statsPath);
+  if (existsSync(statsPath)) {
+    unlinkSync(statsPath);
+  }
 };


### PR DESCRIPTION
When using Gatsby Cloud we have experienced that the stats path does not always exist due to unknown reason.

![image (6)](https://user-images.githubusercontent.com/7723195/100426245-d57b8d00-3090-11eb-991a-a4912b20d8a8.png)
