### PR TITLE
Support Gatsby 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/graysonhicks/gatsby-plugin-loadable-components-ssr",
   "license": "MIT",
   "peerDependencies": {
-    "gatsby": "^2.12.1 || ^3.0.0",
+    "gatsby": "^2.12.1 || ^3.0.0 || ^4.0.0",
     "react-dom": "^16.12.0 || ^17.0.1",
     "@loadable/component": "^5.15.0"
   },


### PR DESCRIPTION
No changes are required in terms of functionality, this plugin supports Gatsby 4. Just to avoid using `--legacy-peer-deps`.